### PR TITLE
fix: wrangler for modern versions

### DIFF
--- a/packages/vite-plugin-cloudflare-functions/src/vite/index.ts
+++ b/packages/vite-plugin-cloudflare-functions/src/vite/index.ts
@@ -104,7 +104,7 @@ export function CloudflarePagesFunctions(userConfig: UserConfig = {}): Plugin {
     let firstTime = true;
     wranglerProcess.stdout.on('data', (chunk) => {
       const text: string = chunk.toString('utf8').slice(0, -1);
-      if (text.indexOf('Compiled Worker successfully.') !== -1) {
+      if (text.indexOf('Compiled Worker successfully') !== -1) {
         if (firstTime) {
           doAutoGen();
           firstTime = false;

--- a/packages/vite-plugin-cloudflare-functions/src/vite/index.ts
+++ b/packages/vite-plugin-cloudflare-functions/src/vite/index.ts
@@ -112,7 +112,7 @@ export function CloudflarePagesFunctions(userConfig: UserConfig = {}): Plugin {
             colors.cyan(url.replace(/:(\d+)\//, (_, port) => `:${colors.bold(port)}/`));
           console.log(
             `  ${colors.green('➜')}  ${colors.bold('Pages')}:   ${colorUrl(
-              `http://127.0.0.1:${wranglerPort}/`
+              `http://localhost:${wranglerPort}/`
             )}\n`
           );
         } else {


### PR DESCRIPTION
### Description

This PR fixes an issue that prevents the `Pages: http://127.0.0.1:8788/` line from being logged to the console as intended, since CF Wrangler now outputs `✨ Compiled Worker successfully` for modern versions instead of `Compiled Worker successfully.`

This also changes `127.0.0.1` to `localhost`, as miniflare does not respond to requests on `127.0.0.1`.